### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO let-go
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: let-go
+
+let-go:
+  defines: runnable
+  metadata:
+    name: let-go
+    description: Main bytecode compiler and VM for let-go, including REPL and nREPL server.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    let-go:
+      image: env-3609.registry.local/let-go:main-73db05b
+      build: .
+      dockerfile: Dockerfile
+  services:
+    http-server:
+      description: HTTP server listening port
+      container: let-go
+      port: 7070
+      host-port: 7070
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - let-go/let-go


### PR DESCRIPTION
# PR Description for Containerization and Deployment Configuration

## Changes Made

- **Containerization**: I've created a Dockerfile for the main let-go application, which is a bytecode compiler and VM for a Clojure-like language. The Dockerfile successfully builds an image that includes the REPL and nREPL server functionalities.
- **Deployment Configuration**: I've added a `monk.yaml` file and a `MANIFEST` file to the repository. These files are necessary for deploying the application using Monk.io.
- **Service Mapping**: The let-go application is the primary service, and it includes a web-based REPL deployable as a separate service. The nREPL server is integrated into the main let-go application and does not require separate deployment.
- **Port Exposure**: The let-go service defaults to exposing port 7070 for its HTTP server, as indicated by the example in the `examples/server.lg` file.

## Encountered Problems

- **WebAssembly Build**: The Dockerfile for the let-go WebAssembly (WASM) build failed due to a missing `go.mod` file in the expected directory. I corrected the Dockerfile to copy the `go.mod` and `go.sum` files from the repository root to the build context. However, a subsequent error occurred during the `make build` command, indicating a missing Go package. This issue needs to be resolved by ensuring all necessary Go packages are available and correctly referenced in the build process.

## Instructions to Continue

- **WASM Dockerfile**: To complete the WASM service containerization, the missing Go package needs to be added or the reference corrected. Once this is done, the Dockerfile should be able to build successfully.
- **Deployment**: After resolving the WASM Dockerfile issue, the PR can be merged. The application will then be re-deployed on each subsequent push, ensuring that the latest version is always running.

## Final Notes

The let-go application is ready for interaction and does not require any additional configuration for its environment variables or connections. The main service is functioning correctly as a standalone REPL and nREPL server. The WebAssembly build requires further attention to ensure successful containerization.