### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO let-go
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,29 @@
+namespace: let-go
+
+let-go-backend:
+  defines: runnable
+  metadata:
+    name: let-go-backend
+    description: >-
+      Backend service for bytecode compilation and VM, including REPL and nREPL
+      server.
+    icon: https://emojiapi.dev/api/v1/crystal_ball.svg
+  containers:
+    let-go-backend:
+      image: env-5164.registry.local/let-go-backend:main-iby00b
+      build: .
+      dockerfile: Dockerfile
+  services: {}
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - let-go/let-go-backend
+  metadata:
+    name: let-go
+    description: >-
+      A bytecode compiler and VM for a Clojure-like language, capable of running
+      as a REPL or nREPL server.
+    icon: https://emojiapi.dev/api/v1/crystal_ball.svg


### PR DESCRIPTION
# PR Description for Containerization and Deployment Configuration

## Containerization of let-go-backend

I've successfully containerized the `let-go-backend` service, which is a bytecode compiler and VM for a Clojure-like language. The service includes a REPL and an nREPL server, and is designed to handle network requests as a backend service. The Dockerfile provided in the repository is suitable for building this service, and no external services such as databases were detected.

- **Dockerfile**: The Dockerfile builds the Go application and copies the binary to the final image. It is set up correctly and the service runs as expected, displaying a prompt for the REPL which indicates it is waiting for user input.
- **Service Behavior**: The service prints a message of the day (motd) when it starts and then enters a loop waiting for input, which is typical for a REPL service. Since the service is running in isolation without user interaction, it is behaving as expected.

## Monk.io Configuration

I've added the necessary Monk.io configuration files to the repository to facilitate deployment.

- **monk.yaml**: Contains the Monk configuration for the service.
- **MANIFEST**: Lists all files containing Monk configurations.

## Deployment Configuration

During the process of configuring the `let-go-backend` service, I encountered an issue with determining the source of the `addr` variable, which is used as the listen address for the HTTP server. The variable's definition could not be found in the Go files within the `./pkg` directory.

- **Configuration Issue**: The source of the `addr` variable is unclear, and it is not indicated to be an environment variable or set elsewhere in the code. This may need to be addressed if the service requires a specific port to be set for HTTP server operation.

## Next Steps

- **Merge PR**: The application is ready to be re-deployed on each subsequent push after merging this PR.
- **Address Configuration Issue**: Further investigation may be required to determine the source of the `addr` variable for the HTTP server's listen address. If a specific port needs to be set, this will need to be resolved.

## Instructions for Continuation

To continue the work on the configuration issue:

1. Investigate the source of the `addr` variable in the `./pkg/rt/http.go` file.
2. Determine if the `addr` variable should be set via an environment variable or if it is defined elsewhere in the codebase.
3. Update the deployment configuration accordingly to ensure the HTTP server operates on the correct port.